### PR TITLE
CTM-182 Fix CTML status field bug

### DIFF
--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -49,6 +49,7 @@ model trial {
   userId                 Int?
   // One trial to many ctml_json records
   ctml_jsons             ctml_json[]
+  trial_status           trial_status
 }
 
 model user {
@@ -73,4 +74,11 @@ enum status {
   DRAFT
   IN_REVIEW
   COMPLETED
+}
+
+enum trial_status {
+  OPEN_TO_ACCRUAL
+  CLOSED_TO_ACCRUAL
+  NOT_YET_RECRUITING
+  RECRUITING
 }

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -75,10 +75,3 @@ enum status {
   IN_REVIEW
   COMPLETED
 }
-
-enum trial_status {
-  OPEN_TO_ACCRUAL
-  CLOSED_TO_ACCRUAL
-  NOT_YET_RECRUITING
-  RECRUITING
-}

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -38,6 +38,7 @@ model trial {
   nct_id                 String
   nickname               String?
   principal_investigator String?
+  // This status refers to the CTML status
   status                 status?       @default(DRAFT)
   // Many trials to many ctml_schema records
   ctml_schemas           ctml_schema[]
@@ -49,7 +50,6 @@ model trial {
   userId                 Int?
   // One trial to many ctml_json records
   ctml_jsons             ctml_json[]
-  trial_status           trial_status
 }
 
 model user {

--- a/apps/api/src/app/trial/dto/create-trial.dto.ts
+++ b/apps/api/src/app/trial/dto/create-trial.dto.ts
@@ -1,5 +1,5 @@
 import {ApiProperty, ApiPropertyOptional} from "@nestjs/swagger";
-import { status, trial_status } from "@prisma/client";
+import { status } from "@prisma/client";
 
 export class CreateTrialDto {
   @ApiProperty()
@@ -26,10 +26,5 @@ export class CreateTrialDto {
     description: "The ID of the schema for this trial data."
   })
   ctml_schema_version: number;
-
-  @ApiProperty({
-    enum: trial_status
-  })
-  trial_status: trial_status;
 
 }

--- a/apps/api/src/app/trial/dto/create-trial.dto.ts
+++ b/apps/api/src/app/trial/dto/create-trial.dto.ts
@@ -1,5 +1,5 @@
 import {ApiProperty, ApiPropertyOptional} from "@nestjs/swagger";
-import {status} from "@prisma/client";
+import { status, trial_status } from "@prisma/client";
 
 export class CreateTrialDto {
   @ApiProperty()
@@ -26,5 +26,10 @@ export class CreateTrialDto {
     description: "The ID of the schema for this trial data."
   })
   ctml_schema_version: number;
+
+  @ApiProperty({
+    enum: trial_status
+  })
+  trial_status: trial_status;
 
 }

--- a/apps/api/src/app/trial/trial.service.ts
+++ b/apps/api/src/app/trial/trial.service.ts
@@ -22,8 +22,8 @@ export class TrialService {
         nickname,
         principal_investigator,
         status,
-        userId: creatingUser.id,
-        modifiedById: creatingUser.id
+        user: { connect: {id: creatingUser.id } },
+        modifiedBy: { connect: {id: creatingUser.id } }
       }
     });
     return newTrial;

--- a/apps/api/src/app/trial/trial.service.ts
+++ b/apps/api/src/app/trial/trial.service.ts
@@ -14,7 +14,7 @@ export class TrialService {
   ) { }
 
   async createTrial(createTrialDto: CreateTrialDto, creatingUser: user) {
-    const { nct_id, nickname, principal_investigator, status } = createTrialDto;
+    const { nct_id, nickname, principal_investigator, status, trial_status } = createTrialDto;
 
     const newTrial = await this.prismaService.trial.create({
       data: {
@@ -23,7 +23,8 @@ export class TrialService {
         principal_investigator,
         status,
         userId: creatingUser.id,
-        modifiedById: creatingUser.id
+        modifiedById: creatingUser.id,
+        trial_status
       }
     });
     return newTrial;

--- a/apps/api/src/app/trial/trial.service.ts
+++ b/apps/api/src/app/trial/trial.service.ts
@@ -14,7 +14,7 @@ export class TrialService {
   ) { }
 
   async createTrial(createTrialDto: CreateTrialDto, creatingUser: user) {
-    const { nct_id, nickname, principal_investigator, status, trial_status } = createTrialDto;
+    const { nct_id, nickname, principal_investigator, status } = createTrialDto;
 
     const newTrial = await this.prismaService.trial.create({
       data: {
@@ -23,8 +23,7 @@ export class TrialService {
         principal_investigator,
         status,
         userId: creatingUser.id,
-        modifiedById: creatingUser.id,
-        trial_status
+        modifiedById: creatingUser.id
       }
     });
     return newTrial;
@@ -74,8 +73,7 @@ export class TrialService {
       principal_investigator,
       nickname,
       ctml_schema_version,
-      nct_id ,
-      trial_status
+      nct_id
     } = updateTrialDto;
     const existing_trial = await this.prismaService.trial.findUnique({
       where: {
@@ -88,7 +86,6 @@ export class TrialService {
         where: { id: existing_trial.id },
         data: {
           status,
-          trial_status,
           principal_investigator,
           nickname,
           nct_id,
@@ -107,9 +104,8 @@ export class TrialService {
         nickname,
         principal_investigator,
         status,
-        trial_status,
-        userId: user.id,
-        modifiedById: user.id,
+        user: { connect: { id: user.id } },
+        modifiedBy: { connect: { id: user.id } },
         ctml_schemas: {
           connect: {
             version: ctml_schema_version

--- a/apps/api/src/app/trial/trial.service.ts
+++ b/apps/api/src/app/trial/trial.service.ts
@@ -68,7 +68,14 @@ export class TrialService {
                user: user
   ): Promise<trial> {
 
-    const { status, principal_investigator, nickname, ctml_schema_version, nct_id } = updateTrialDto;
+    const {
+      status,
+      principal_investigator,
+      nickname,
+      ctml_schema_version,
+      nct_id ,
+      trial_status
+    } = updateTrialDto;
     const existing_trial = await this.prismaService.trial.findUnique({
       where: {
         id
@@ -80,6 +87,7 @@ export class TrialService {
         where: { id: existing_trial.id },
         data: {
           status,
+          trial_status,
           principal_investigator,
           nickname,
           nct_id,

--- a/apps/api/src/app/trial/trial.service.ts
+++ b/apps/api/src/app/trial/trial.service.ts
@@ -84,7 +84,7 @@ export class TrialService {
     });
 
     if (existing_trial) {
-      return await this.prismaService.trial.update({
+      return this.prismaService.trial.update({
         where: { id: existing_trial.id },
         data: {
           status,
@@ -101,12 +101,13 @@ export class TrialService {
       });
     }
 
-    return await this.prismaService.trial.create({
+    return this.prismaService.trial.create({
       data: {
         nct_id,
         nickname,
         principal_investigator,
         status,
+        trial_status,
         userId: user.id,
         modifiedById: user.id,
         ctml_schemas: {

--- a/apps/web/components/editor/EditorTopBar.tsx
+++ b/apps/web/components/editor/EditorTopBar.tsx
@@ -88,7 +88,7 @@ const EditorTopBar = (props: {isEditMode?: boolean}) => {
         nct_id: ctmlModel.trialInformation.trial_id,
         nickname: ctmlModel.trialInformation.nickname,
         principal_investigator: ctmlModel.trialInformation.principal_investigator,
-        status: ctmlModel.trialInformation.status,
+        status: ctmlModel.trialInformation.ctml_status
       }
     }
 


### PR DESCRIPTION
Originally, filling in the status field would cause an error on save. This was due to the fields `status` and `ctml_status` mmixed up. This has been corrected. In addition, another bug was found in the trial entity creation that has been fixed.