### PR TITLE
CTM-168 Display CTML status enums as labels in table

### DIFF
--- a/apps/web/hooks/useGetUserTrials.tsx
+++ b/apps/web/hooks/useGetUserTrials.tsx
@@ -3,6 +3,7 @@ import {useSession} from "next-auth/react";
 import {useEffect, useState} from "react";
 import {useRouter} from "next/router";
 import getConfig from 'next/config';
+import { getCtmlStatusLabel } from "../../../libs/types/src/CtmlStatusLabels";
 
 const useGetUserTrials = () => {
   const { publicRuntimeConfig } = getConfig();
@@ -52,10 +53,12 @@ const useGetUserTrials = () => {
           hour: 'numeric',
           minute: 'numeric'
         });
+        const ctml_status_label = getCtmlStatusLabel(trial.status);
         return {
           ...trial,
           createdAt: createdAtFormatted,
-          updatedAt: updatedAtFormatted
+          updatedAt: updatedAtFormatted,
+          ctml_status_label
         }
       })
       setResponse(mapped)

--- a/apps/web/pages/trials/index.tsx
+++ b/apps/web/pages/trials/index.tsx
@@ -179,7 +179,7 @@ const Trials = () => {
             <Column field="id" header="" body={subMenuTemplate}></Column>
             <Column field="nickname" header="Nickname"></Column>
             <Column field="principal_investigator" header="Principal Investigator" ></Column>
-            <Column field="status" header="CTML Status" sortable></Column>
+            <Column field="ctml_status_label" header="CTML Status" sortable></Column>
             <Column field="createdAt" header="Created on" dataType="date"></Column>
             <Column field="updatedAt" header="Modified on" dataType="date"></Column>
           </DataTable>

--- a/libs/types/src/CtmlStatusLabels.ts
+++ b/libs/types/src/CtmlStatusLabels.ts
@@ -1,0 +1,17 @@
+import { CtmlStatusEnum } from "./ctml-status.enum";
+
+export const CtmlStatusLabels: Record<CtmlStatusEnum, string> = {
+  [CtmlStatusEnum.DRAFT]: "Draft",
+  [CtmlStatusEnum.IN_REVIEW]: "In Review",
+  [CtmlStatusEnum.COMPLETED]: "Completed",
+};
+
+/**
+ * Retrieves the label associated with the given value from the CtmlStatusLabels mapping.
+ * @param {string} value - The value for which to retrieve the label.
+ * @returns {string | undefined} The label associated with the value, or undefined if not found.
+ */
+export function getCtmlStatusLabel(enumVal: CtmlStatusEnum): string | undefined {
+  const label = CtmlStatusLabels[enumVal];
+  return label;
+}

--- a/libs/types/src/ctml-status.enum.ts
+++ b/libs/types/src/ctml-status.enum.ts
@@ -1,0 +1,5 @@
+export enum CtmlStatusEnum {
+  "DRAFT" = "DRAFT",
+  "IN_REVIEW" = "IN_REVIEW" ,
+  "COMPLETED" = "COMPLETED"
+}


### PR DESCRIPTION
This commit adds
- An enum for CTML status in ctml-status.enum.ts
- A mapping from the CtmlStatusEnum to the assoc labels in CtmlStatusLabels.ts
- A function to get the mapped label in CtmlStatusLabels.ts
- Adding the labels to the trials table