### PR TITLE
Dheeraj_CTM-592

### DIFF
--- a/apps/web/components/trials/Results.tsx
+++ b/apps/web/components/trials/Results.tsx
@@ -153,7 +153,7 @@ const Results = (props: {trials: [], getTrialsForUsersInGroupLoading: boolean}) 
         matchedDate: cur.matchedDate? cur.matchedDate : '',
         trialStatus: cur.trialStatus,
         short_title: cur.short_title,
-        matchSentDate: cur.matchSentDate? cur.matchSentDate: ''
+        matchSentDate: cur.matchSentDate
       }
       dataCopy.push(curCopy);
     }

--- a/apps/web/hooks/useGetMatchResults.tsx
+++ b/apps/web/hooks/useGetMatchResults.tsx
@@ -61,7 +61,7 @@ const useGetMatchResults = () => {
         if (trialWithResult) {
           const createdAtDate = new Date(trialWithResult.createdAt);
           const updatedAtDate = new Date(trialWithResult.updatedAt);
-          const matchSentDate = new Date(trialWithResult.matchSentDate);
+          const matchSentDate = trialWithResult.matchSentDate ? new Date(trialWithResult.matchSentDate) : "";
           const matchedDateFormatted = trialWithResult.matchedDate ? new Date(trialWithResult.matchedDate).toLocaleString(undefined, {
                   month: 'short',
                   day: 'numeric',


### PR DESCRIPTION
If a trial has a null matchSentDate, return an empty string instead of the default date.