### PR TITLE
Single user mode, adding no Keycloak support

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -15,6 +15,23 @@ KEYCLOAK_REALM=ctims
 # The realm needs to have client authentication enabled to see the Credentials tab.
 KEYCLOAK_CLIENT_SECRET=<secret>
 
+# To disable key cloak change the KEYCLOAK_DISABLED value to true and use the below login details to login.
+KEYCLOAK_DISABLED=false
+KD_TRIALGROUP=default
+KD_TRIALGROUP_ADMIN=default-admin
+KD_USERNAME=ctims
+KD_PASSWORD=ctims
+KD_USERNAME_ADMIN=ctims-admin
+KD_PASSWORD_ADMIN=ctims-admin
+KD_EMAIL=ctims@uhn.ca
+KD_EMAIL_ADMIN=ctimsadmin@uhn.ca
+KD_FULLNAME=Ctims User
+KD_FULLNAME_ADMIN=Ctims Admin
+KD_KEYCLOAK_ID=1234
+KD_KEYCLOAK_ID_ADMIN=5678
+KD_TOKEN_ADMIN="env-based-token-admin"
+KD_TOKEN_USER="env-based-token-user"
+
 # A client with service account enabled.
 # It does not need to be a separate client. If your above client already has service account enabled, use the same ID here.
 KEYCLOAK_ADMIN_CLIENT_ID=ctims-admin

--- a/apps/api/src/app/auth/KeycloakPasswordGuard.ts
+++ b/apps/api/src/app/auth/KeycloakPasswordGuard.ts
@@ -1,14 +1,31 @@
 import { ExecutionContext, Injectable, UnauthorizedException } from "@nestjs/common";
 import { AuthGuard as PassportAuthGuard } from '@nestjs/passport';
+import { keycloak_disabled_comfig } from "./keycloak-disabled-config";
 
 @Injectable()
 export class KeycloakPasswordGuard extends PassportAuthGuard('keycloak') {
+  private keycloakDisabled: boolean;
+  private envTokenAdmin: string;
+  
+  constructor() {
+    super();
+    this.keycloakDisabled = process.env.KEYCLOAK_DISABLED === 'true';
+    this.envTokenAdmin = process.env.KD_TOKEN_ADMIN;
+  }
   getRequest(context: ExecutionContext) {
     const req =  context.switchToHttp().getRequest();
     return req;
   }
 
   handleRequest(err: any, user: any, info: any, context: ExecutionContext) {
+    if (this.keycloakDisabled) {
+      const req = context.switchToHttp().getRequest();
+      const authHeader = req.headers.authorization;
+      const token = authHeader ? authHeader.split(' ')[1] : null;
+      const isAdmin = (token == this.envTokenAdmin) ? "admin" : "notadmin";
+      const user = keycloak_disabled_comfig(isAdmin);
+      return user;
+    }
     if (err || !user) {
       console.log('Error:', err);
       console.log('Info:', info);

--- a/apps/api/src/app/auth/keycloak-disabled-config.ts
+++ b/apps/api/src/app/auth/keycloak-disabled-config.ts
@@ -50,5 +50,5 @@ function keycloak_disabled_fetch_by_KeycloakId(role: string) {
 function adminStatus(role: string){
     return (role=="admin") ? true : false;
 }
-export { keycloak_disabled_comfig, keycloak_disabled_fetch_by_KeycloakId };
+export { keycloak_disabled_comfig, keycloak_disabled_fetch_by_KeycloakId, adminStatus};
 

--- a/apps/api/src/app/auth/keycloak-disabled-config.ts
+++ b/apps/api/src/app/auth/keycloak-disabled-config.ts
@@ -1,0 +1,54 @@
+function keycloak_disabled_comfig(role: string) {
+
+    const envUsername = adminStatus(role) ? process.env.KD_USERNAME_ADMIN : process.env.KD_USERNAME;
+    const envTrialGroup = adminStatus(role) ? process.env.KD_TRIALGROUP_ADMIN : process.env.KD_TRIALGROUP;
+    const envKeycloakId = adminStatus(role) ? process.env.KD_KEYCLOAK_ID_ADMIN : process.env.KD_KEYCLOAK_ID;
+    const envEmail = adminStatus(role) ? process.env.KD_EMAIL_ADMIN : process.env.KD_EMAIL
+    const envFullName = adminStatus(role) ? process.env.KD_FULLNAME_ADMIN : process.env.KD_FULLNAME;
+    const roles = envTrialGroup;
+    const userId = adminStatus(role) ? 100 : 99;
+
+    const user = {
+        id: userId,
+        email: envEmail,
+        name: envFullName,
+        username: envUsername,
+        first_name: envUsername,
+        email_verified: true,
+        last_name: '',
+        keycloak_id: envKeycloakId,
+        createdAt: "",
+        updatedAt: "",
+        roles: [roles]
+    }
+    return user;
+}
+function keycloak_disabled_fetch_by_KeycloakId(role: string) {
+
+    const envUsername = adminStatus(role) ? process.env.KD_USERNAME_ADMIN : process.env.KD_USERNAME;
+    const envTrialGroup = adminStatus(role) ? process.env.KD_TRIALGROUP_ADMIN : process.env.KD_TRIALGROUP;
+    const envKeycloakId = adminStatus(role) ? process.env.KD_KEYCLOAK_ID_ADMIN : process.env.KD_KEYCLOAK_ID;
+    const envEmail = adminStatus(role) ? process.env.KD_EMAIL_ADMIN : process.env.KD_EMAIL
+    const envFullName = adminStatus(role) ? process.env.KD_FULLNAME_ADMIN : process.env.KD_FULLNAME;
+    const roles = envTrialGroup;
+
+    const user = {
+        id: envKeycloakId,
+        email: envEmail,
+        name: envFullName,
+        username: envUsername,
+        first_name: envUsername,
+        email_verified: true,
+        last_name: '',
+        keycloak_id: envKeycloakId,
+        createdAt: "",
+        updatedAt: "",
+        roles: [roles]
+    }
+    return user;
+}
+function adminStatus(role: string){
+    return (role=="admin") ? true : false;
+}
+export { keycloak_disabled_comfig, keycloak_disabled_fetch_by_KeycloakId };
+

--- a/apps/api/src/app/trial/trial-group.service.ts
+++ b/apps/api/src/app/trial/trial-group.service.ts
@@ -3,6 +3,7 @@ import axios, {AxiosResponse} from 'axios';
 import { PrismaService } from '../prisma.service';
 import { ModuleRef } from '@nestjs/core';
 import { trial } from '@prisma/client';
+import { keycloak_disabled_fetch_by_KeycloakId } from "../auth/keycloak-disabled-config";
 
 export interface TrialGroup {
   id: string;
@@ -95,6 +96,13 @@ export class TrialGroupService {
 
   async getUsersInTrialGroup(trialGroupId: string): Promise<any[]> {
 
+    const isKeycloakDisabled = process.env.KEYCLOAK_DISABLED === 'true';
+    if (isKeycloakDisabled) {
+      const user = keycloak_disabled_fetch_by_KeycloakId("notadmin");
+      const adminUser = keycloak_disabled_fetch_by_KeycloakId("admin");
+      return [user, adminUser];
+    }
+    else {
     try {
       const accessToken = await this.getToken();
       const getUsersInTrialGroupConfig = {
@@ -126,6 +134,7 @@ export class TrialGroupService {
     } catch (error) {
       this.logger.error(`Error while getting users in trial group from Keycloak: ${error}`)
       throw new HttpException('Error while getting users in trial group from Keycloak', HttpStatus.BAD_REQUEST)
+      }
     }
   }
 

--- a/apps/api/src/app/user/user.service.ts
+++ b/apps/api/src/app/user/user.service.ts
@@ -6,6 +6,7 @@ import {PrismaService} from "../prisma.service";
 import {KeycloakPasswordStrategy} from "../auth/keycloak-password.strategy";
 import {ModuleRef} from "@nestjs/core";
 import { PrismaPromise, user } from "@prisma/client";
+import {adminStatus} from "../auth/keycloak-disabled-config";
 
 @Injectable()
 export class UserService {
@@ -37,12 +38,12 @@ export class UserService {
   }
 
   async createUserWithoutKeycloak(role: string) {
-    const envUsername = (role == "admin") ? process.env.KD_USERNAME_ADMIN : process.env.KD_USERNAME;
-    const envKeycloakId = (role == "admin") ? process.env.KD_KEYCLOAK_ID_ADMIN : process.env.KD_KEYCLOAK_ID;
-    const envEmail = (role == "admin") ? process.env.KD_EMAIL_ADMIN : process.env.KD_EMAIL;
-    const envFullName = (role == "admin") ? process.env.KD_FULLNAME_ADMIN : process.env.KD_FULLNAME;
-    const Id = (role == "admin") ? 100 : 99;
-    const token = (role == "admin") ?  process.env.KD_TOKEN_ADMIN : process.env.KD_TOKEN_USER ;
+    const envUsername = adminStatus(role) ? process.env.KD_USERNAME_ADMIN : process.env.KD_USERNAME;
+    const envKeycloakId = adminStatus(role) ? process.env.KD_KEYCLOAK_ID_ADMIN : process.env.KD_KEYCLOAK_ID;
+    const envEmail = adminStatus(role) ? process.env.KD_EMAIL_ADMIN : process.env.KD_EMAIL;
+    const envFullName = adminStatus(role) ? process.env.KD_FULLNAME_ADMIN : process.env.KD_FULLNAME;
+    const Id = adminStatus(role) ? 100 : 99;
+    const token = adminStatus(role) ?  process.env.KD_TOKEN_ADMIN : process.env.KD_TOKEN_USER ;
     const newUserWithoutKeycloak = await this.prismaService.user.create({
       data: {
         id: Id,

--- a/apps/api/src/app/user/user.service.ts
+++ b/apps/api/src/app/user/user.service.ts
@@ -36,6 +36,29 @@ export class UserService {
     return newUserFromKeycloak;
   }
 
+  async createUserWithoutKeycloak(role: string) {
+    const envUsername = (role == "admin") ? process.env.KD_USERNAME_ADMIN : process.env.KD_USERNAME;
+    const envKeycloakId = (role == "admin") ? process.env.KD_KEYCLOAK_ID_ADMIN : process.env.KD_KEYCLOAK_ID;
+    const envEmail = (role == "admin") ? process.env.KD_EMAIL_ADMIN : process.env.KD_EMAIL;
+    const envFullName = (role == "admin") ? process.env.KD_FULLNAME_ADMIN : process.env.KD_FULLNAME;
+    const Id = (role == "admin") ? 100 : 99;
+    const token = (role == "admin") ?  process.env.KD_TOKEN_ADMIN : process.env.KD_TOKEN_USER ;
+    const newUserWithoutKeycloak = await this.prismaService.user.create({
+      data: {
+        id: Id,
+        email: envEmail,
+        keycloak_id: envKeycloakId,
+        first_name: envUsername,
+        last_name: "",
+        name: envFullName,
+        username: envUsername,
+        email_verified: true,
+        refresh_token: token
+      }
+    });
+    return newUserWithoutKeycloak;
+  }
+
   findAll() {
     return `This action returns all user`;
   }


### PR DESCRIPTION
Changes:

1. Added new env variables which are required for authentication and disabling keycloak.
2. Making sure KeycloakPasswordGuard is diabled when KEYCLOAK_DISABLED value is set to true in env file.
3. Created a new file called keycloak_disabled_comfig to send the user details upon authentication.
4. Added few changes to add default users in db when logging in for the first time.
